### PR TITLE
Add search_tool wrapper for agents

### DIFF
--- a/src/retrieval/retriever.py
+++ b/src/retrieval/retriever.py
@@ -102,3 +102,43 @@ def search(query: str, mode: str = "soft", k: int = DEFAULT_K) -> List[Dict[str,
     if mode == "base":
         return search_base(query, k)
     return search_soft(query, k)
+
+
+
+    # --- Tool output for Agents / LangGraph ---
+def search_tool(query: str, k: int = DEFAULT_K, mode: str = "soft", max_chars: int = 3500) -> str:
+    """
+    Devuelve contexto listo para LLM (string), basado en la búsqueda del vectorstore.
+    - No cambia la API 'search()' (que devuelve hits crudos).
+    - Este wrapper es para agentes: texto limpio + fuentes.
+    """
+    hits = search(query=query, mode=mode, k=k)
+
+    if not hits:
+        return "NO_RESULTS"
+
+    blocks = []
+    sources = []
+
+    for i, h in enumerate(hits, start=1):
+        meta = h.get("metadata", {}) or {}
+        src = meta.get("source", "unknown")
+        file = meta.get("file", "unknown")
+        unit = meta.get("unit_title") or meta.get("unit_id") or meta.get("unit_type") or ""
+
+        sources.append(f"{src}:{file}:{unit}".strip(":"))
+
+        text = (h.get("text") or "").strip()
+        if not text:
+            continue
+
+        blocks.append(f"[{i}] source={src} file={file}\n{text}")
+
+    out = "CONTEXT:\n" + "\n\n".join(blocks)
+    out += "\n\nSOURCES:\n" + "\n".join(sorted(set(sources)))
+
+    # Recorte por seguridad
+    if len(out) > max_chars:
+        out = out[:max_chars] + "\n\n[TRUNCATED]"
+
+    return out


### PR DESCRIPTION
Maru, te dejo cómo conectarte al retrieval actualizado.

Hay dos formas:

1) Para prueba humana (debug / notebook / sanity check):

from src.retrieval.retriever import search

results = search("consulta aquí", k=3)
print(results)

Esto devuelve la lista estructurada (id, text, metadata, distance).
Sirve para inspección manual.


2) Para conectar el agente (LangGraph / LLM tool calling):

from src.retrieval.retriever import search_tool

context = search_tool("consulta aquí", k=3)

Este devuelve un STRING ya formateado:
- CONTEXT con los chunks relevantes
- SOURCES consolidadas
- listo para pasarlo directamente al LLM


Ejemplo de uso dentro del agente:

from src.retrieval.retriever import search_tool
from langchain_openai import ChatOpenAI

llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)

query = "¿Qué obligaciones tiene un sistema de alto riesgo según el AI Act?"

context = search_tool(query, k=3)

final_prompt = f"""
Usa únicamente el siguiente contexto para responder.
Si no está en el contexto, di que no lo sabes.

{context}

Pregunta:
{query}
"""

response = llm.invoke(final_prompt)
print(response.content)


Importante:
- El vectorstore está persistido en processed/vectorstore/chroma
- Está versionado con DVC
- No depende de estado local oculto
- Validado fuera del venv (simulando entorno limpio)

Con esto puedes enchufarlo directamente como tool en el grafo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de la versión

* **Nuevas Funcionalidades**
  * Se implementó una nueva herramienta de búsqueda que proporciona resultados con un formato estructurado y fácil de leer. Los usuarios ahora pueden acceder a información organizada en bloques de contexto claramente definidos, junto con fuentes citadas y debidamente referenciadas. Los resultados se ajustan automáticamente según el límite máximo de caracteres especificado.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->