### PR TITLE
feature/rag-main: conecta retriever al rag pipeline con Ollama

### DIFF
--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -12,4 +12,4 @@ langchain-core>=0.3.0
 chromadb
 
 # LLM providers
-# TODO: añadir groq, google-generativeai, mistralai cuando se integren
+langchain-ollama>=0.3.0

--- a/src/rag/main.py
+++ b/src/rag/main.py
@@ -1,19 +1,88 @@
 """rag/main.py — Agente RAG Normativo (Corrective RAG)
-Hello world: simula el flujo Retrieve → Grade → Generate con citas.
+Flujo Retrieve → Grade → Generate con citas legales desde ChromaDB.
 """
 
+import logging
 
-def retrieve(query: str) -> list[dict]:
-    # TODO: reemplazar con ChromaDB query real
+from langchain_ollama import ChatOllama
+
+from src.retrieval.retriever import search
+
+logger = logging.getLogger(__name__)
+
+GRADING_PROMPT = (
+    "Dado el siguiente documento y la pregunta, "
+    "¿el documento contiene información útil para responder la pregunta?\n\n"
+    "Documento: {document}\n"
+    "Pregunta: {query}\n\n"
+    'Responde solo con "si" o "no":'
+)
+
+_grading_llm = None
+
+
+def _get_grading_llm():
+    """Devuelve el LLM local para grading (Qwen 2.5 3B via Ollama)."""
+    global _grading_llm
+    if _grading_llm is None:
+        _grading_llm = ChatOllama(
+            model="qwen2.5:3b",
+            temperature=0,
+            num_predict=10,
+        )
+    return _grading_llm
+
+
+def retrieve(query: str, k: int = 5) -> list[dict]:
+    """Recupera documentos de ChromaDB y los formatea para grade()."""
+    try:
+        results = search(query, k=k, mode="soft")
+    except Exception:
+        logger.exception("Error al buscar en ChromaDB")
+        return []
+
     return [
-        {"doc": "Art. 5: Quedan prohibidas las prácticas de IA que manipulen el comportamiento humano.", "metadata": {"ley": "EU AI Act", "articulo": "5"}, "score": 0.89},
-        {"doc": "Art. 6: Los sistemas de alto riesgo del Anexo III deberán cumplir requisitos.", "metadata": {"ley": "EU AI Act", "articulo": "6"}, "score": 0.62},
+        {
+            "doc": r["text"],
+            "metadata": r.get("metadata", {}),
+            "score": max(0.0, 1.0 - r.get("distance", 1.0)),
+        }
+        for r in results
     ]
 
 
-def grade(docs: list[dict], threshold: float = 0.7) -> list[dict]:
-    # TODO: reemplazar con LLM que evalúe relevancia
-    relevant = [d for d in docs if d["score"] >= threshold]
+def _grade_by_score(docs: list[dict], threshold: float = 0.7) -> list[dict]:
+    """Fallback: filtra documentos por score de similitud."""
+    return [d for d in docs if d["score"] >= threshold]
+
+
+def grade(query: str, docs: list[dict], threshold: float = 0.7) -> list[dict]:
+    """Evalúa relevancia de cada documento con LLM local (Ollama).
+
+    Fallback a filtro por score si Ollama no está disponible.
+    """
+    if not docs:
+        return []
+
+    try:
+        llm = _get_grading_llm()
+    except Exception:
+        logger.warning("Ollama no disponible, usando fallback por score")
+        return _grade_by_score(docs, threshold)
+
+    relevant = []
+    for doc in docs:
+        prompt = GRADING_PROMPT.format(document=doc["doc"], query=query)
+        try:
+            response = llm.invoke(prompt)
+            answer = response.content.strip().lower()
+            if answer.startswith("si") or answer.startswith("sí"):
+                relevant.append(doc)
+        except Exception:
+            logger.warning("Error en grading LLM, incluyendo doc por score")
+            if doc["score"] >= threshold:
+                relevant.append(doc)
+
     return relevant
 
 
@@ -34,8 +103,8 @@ if __name__ == "__main__":
     docs = retrieve(query)
     print(f"Retrieve:  {len(docs)} docs encontrados")
 
-    relevant = grade(docs)
-    print(f"Grade:     {len(relevant)} relevantes (threshold=0.7)")
+    relevant = grade(query, docs)
+    print(f"Grade:     {len(relevant)} relevantes")
 
     result = generate(query, relevant)
     print(f"Generate:  {result['answer']}")

--- a/src/retrieval/retriever.py
+++ b/src/retrieval/retriever.py
@@ -10,10 +10,19 @@ CHROMA_DIR = Path(__file__).resolve().parents[2] / "data" / "processed" / "vecto
 COLLECTION_NAME = "normabot_legal_chunks"
 
 
-# Inicialización Chroma
+# Inicialización Chroma (lazy)
 
-_client = chromadb.PersistentClient(path=str(CHROMA_DIR))
-_collection = _client.get_collection(COLLECTION_NAME)
+_client = None
+_collection = None
+
+
+def _get_collection():
+    """Inicializa el cliente ChromaDB y obtiene la colección de forma lazy."""
+    global _client, _collection
+    if _collection is None:
+        _client = chromadb.PersistentClient(path=str(CHROMA_DIR))
+        _collection = _client.get_collection(COLLECTION_NAME)
+    return _collection
 
 
 # Funciones internas
@@ -57,7 +66,8 @@ def _detect_priority_sources(query: str) -> Optional[List[str]]:
 # Búsqueda BASE
 
 def search_base(query: str, k: int = DEFAULT_K) -> List[Dict[str, Any]]:
-    results = _collection.query(
+    collection = _get_collection()
+    results = collection.query(
         query_texts=[query],
         n_results=k
     )
@@ -70,7 +80,8 @@ def search_base(query: str, k: int = DEFAULT_K) -> List[Dict[str, Any]]:
 def search_soft(query: str, k: int = DEFAULT_K) -> List[Dict[str, Any]]:
     priority_sources = _detect_priority_sources(query)
 
-    results = _collection.query(
+    collection = _get_collection()
+    results = collection.query(
         query_texts=[query],
         n_results=k * 2
     )


### PR DESCRIPTION
## ¿Qué hace este PR?
src/rag/main.py — retrieve() conectado a ChromaDB real
grade(query, docs) ahora usa Qwen 2.5 3B via Ollama (modelo local) para evaluar relevancia

## Checklist (si aplica)
- [x] He documentado mis decisiones en la documentación del proyecto.
- [ ] El código pasa los tests localmente.
- [ ] He probado los cambios manualmente.

## ¿Afecta al trabajo de otros?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Nueva capacidad de clasificación automática de documentos que mejora significativamente la relevancia de los resultados recuperados.
  * Manejo mejorado de errores con fallback automático cuando la clasificación inteligente no está disponible.
  * Mejor soporte para proveedores de modelos de lenguaje locales.

* **Refactor**
  * Optimización interna del sistema de recuperación de datos para mejorar el rendimiento general.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->