### PR TITLE
Arreglar .dockerignore para que utilice .sh

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,7 @@ data/
 
 # Infraestructura y docs
 infra/
+!infra/ollama-entrypoint.sh
 docs/
 
 # Git


### PR DESCRIPTION
## ¿Qué hace este PR?
Se me escapó que el dockerignore quita infra y el sh que hace falta para ollama está ahí. Esto lo corrige.

## Checklist (si aplica)
- [ ] He documentado mis decisiones en la documentación del proyecto.
- [ ] El código pasa los tests localmente.
- [ ] He probado los cambios manualmente.

## ¿Afecta al trabajo de otros?
Es para el despliegue.