### PR TITLE
Actualización para reflejar limitación de langfuse

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,22 +50,5 @@ if prompt := st.chat_input("Escribe tu consulta legal..."):
         response = messages[-1].content if messages else "Sin respuesta."
         st.markdown(response)
 
-        trace_id = result.get("_langfuse_trace_id")
-        if trace_id:
-            col1, col2, _ = st.columns([1, 1, 8])
-            with col1:
-                if st.button("👍", key=f"up_{len(st.session_state.messages)}"):
-                    try:
-                        from langfuse import Langfuse
-                        Langfuse().score(trace_id=trace_id, name="user_feedback", value=1)
-                    except Exception:
-                        pass
-            with col2:
-                if st.button("👎", key=f"down_{len(st.session_state.messages)}"):
-                    try:
-                        from langfuse import Langfuse
-                        Langfuse().score(trace_id=trace_id, name="user_feedback", value=0)
-                    except Exception:
-                        pass
 
     st.session_state.messages.append({"role": "assistant", "content": response})

--- a/docs/mlops/decisiones.md
+++ b/docs/mlops/decisiones.md
@@ -93,5 +93,5 @@ De momento solo hay una para MLflow. Es preferible usar SQLite dentro de la prop
         * `retriever.py` — search y search_tool: registra distancias min/max, número de resultados, fuentes únicas y si el contexto fue truncado.
         * `orchestrator/main.py` — las 3 herramientas del agente (search_legal_docs, classify_risk, generate_report) con `@observe`.
     * **Limitación conocida**: la traza raíz del agente LangGraph vía `CallbackHandler` no está disponible. `langfuse.callback` en v2.60.x requiere `langchain.callbacks.base` que fue eliminado en langchain 0.3. Las trazas individuales de cada herramienta sí llegan a Langfuse vía `@observe`.
-    * Feedback de usuario (👍/👎) registrado como score en Langfuse directamente desde la UI de Streamlit.
+    * Feedback de usuario (👍/👎): eliminado — dependía del `trace_id` del `CallbackHandler` raíz, que no está disponible por incompatibilidad entre `langfuse.callback` v2 y `langchain` 0.3.
     * En tests, Langfuse se desactiva con `LANGFUSE_ENABLED=false` en `tests/conftest.py` para evitar dependencias de credenciales en CI.

--- a/src/orchestrator/main.py
+++ b/src/orchestrator/main.py
@@ -243,11 +243,6 @@ def run(query: str, session_id: str | None = None, user_id: str | None = None) -
         {"messages": [("user", query)]},
         config={"callbacks": callbacks},
     )
-    # Exponer el trace_id de Langfuse para que la UI pueda añadir scores de feedback
-    if callbacks:
-        trace_id = getattr(callbacks[0], "trace_id", None)
-        if trace_id:
-            result["_langfuse_trace_id"] = trace_id
     return result
 
 


### PR DESCRIPTION
## ¿Qué hace este PR?
Elimina los botones de valoración de respuestas (👍/👎) de la UI y código relacionado que no es necesario ya.

Los botones necesitaban el ID de la sesión de Langfuse para registrar la puntuación. Ese ID venía del componente que conecta el agente con Langfuse (`CallbackHandler`), que no funciona porque la versión de Langfuse que usamos (v2) no es compatible con la versión de LangChain que tenemos instalada (0.3): el módulo interno que necesita (`langchain.callbacks.base`) fue eliminado en LangChain 0.3.

Ahora mismo en vez de poder ver las trazas como:
```
▼ normabot-agent  (consulta completa, tokens totales, latencia end-to-end)
  ├── tool: search_legal_docs  → retrieve → grade → generate
  ├── tool: classify_risk      → predict_risk
  └── tool: generate_report    → generate_report
```

Las vemos así:
```
- classifier.predict_risk
- rag.retrieve
- rag.grade
- report.generate_report
```

Para un MVP es suficiente.  Las trazas de cada herramienta individual (RAG, clasificador, informe) siguen llegando a Langfuse con normalidad a través de `@observe` y podemos evaluar que el sistema funciona con eso.

## Checklist (si aplica)
- [x] He documentado mis decisiones en la documentación del proyecto.
- [x] El código pasa los tests localmente.
- [x] He probado los cambios manualmente.

## ¿Afecta al trabajo de otros?
Los botones 👍/👎 ya no existen en la UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de la Versión

* **Bug Fixes**
  * Se eliminó la interfaz de retroalimentación del usuario (botones de pulgar hacia arriba y hacia abajo) de las respuestas del asistente en la aplicación.

* **Documentation**
  * Actualizada la documentación técnica reflejando cambios en versiones de dependencias del sistema, limitaciones conocidas en la observabilidad y ajustes en los mecanismos de instrumentación de trazas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->