### PR TITLE
Bug 1: arreglar bug de _annex3_override

### DIFF
--- a/docs/mlops/decisiones.md
+++ b/docs/mlops/decisiones.md
@@ -78,7 +78,7 @@ De momento solo hay una para MLflow. Es preferible usar SQLite dentro de la prop
     * `cicd-main.yml`: lint completo + smoke tests (pytest) + construye, publica con tag `:latest` y despliega automáticamente en el servidor en cada push a `main`. Los tests también corren en PRs a `main` como gate antes del merge.
     * `eval.yml`: ejecuta la evaluación RAGAS en EC2 contra la imagen `:latest` desplegada. Se lanza manualmente (`workflow_dispatch`).
 * El despliegue se hace vía SSH a la EC2. El script de deploy hace login en GHCR, `dvc pull` del vectorstore y levanta el contenedor con `docker compose up -d --pull always --force-recreate`. Pendiente: valorar si simplificar a `docker run` directo.
-* Los smoke tests (69 tests, 4 suites: clasificador, RAG generate, orquestador, reentrenamiento) se ejecutan con `pytest tests/ -v`. Los servicios externos (Bedrock, Ollama) están mockeados y el reentrenamiento usa un stub `_FakeXGB`, por lo que no requieren credenciales ni entrenamiento real en CI.
+* Los smoke tests (79 tests, 4 suites: clasificador, RAG generate, orquestador, reentrenamiento) se ejecutan con `pytest tests/ -v`. Los servicios externos (Bedrock, Ollama) están mockeados y el reentrenamiento usa un stub `_FakeXGB`, por lo que no requieren credenciales ni entrenamiento real en CI. El clasificador incluye `TestAnnex3Override` (10 tests) que verifica la coherencia de `risk_level`, `confidence` y `probabilities` cuando `_annex3_override` actúa, llamando directamente a la función con un resultado ML intencionalmente incorrecto para no depender de las predicciones del modelo.
 
 ## Observabilidad y trazabilidad
 * Usamos [MLflow](https://mlflow.org/) para los modelos de clasificación: métricas de entrenamiento y registro del modelo.

--- a/docs/mlops/guia-de-trabajo.md
+++ b/docs/mlops/guia-de-trabajo.md
@@ -313,8 +313,8 @@ pytest tests/ -v
 pytest tests/ -v -s
 ```
 
-Hay cuatro suites de smoke tests (69 tests en total):
-- `test_classifier.py` — 19 tests: estructura de `predict_risk()`, robustez, explicabilidad SHAP, validación de entrada.
+Hay cuatro suites de smoke tests (79 tests en total):
+- `test_classifier.py` — 29 tests: estructura de `predict_risk()`, robustez, explicabilidad SHAP, validación de entrada, y coherencia de campos tras el override del Anexo III (`TestAnnex3Override`).
 - `test_rag_generate.py` — 13 tests: prompt, singleton `_get_generate_llm()`, flujo `generate()` con fallback.
 - `test_orchestrator.py` — 23 tests: SYSTEM_PROMPT con requisitos legales, nombres y descripciones de las 3 tools, validación de entrada, comportamiento de `classify_risk`, `search_legal_docs` y `generate_report`, contrato de `run()`.
 - `test_retrain.py` — 14 tests: limpieza de texto, carga de JSONL, features manuales e integración de `main()` con `monkeypatch` de rutas y stub `_FakeXGB` (sin entrenamiento real).

--- a/src/classifier/main.py
+++ b/src/classifier/main.py
@@ -125,11 +125,21 @@ def _annex3_override(text: str, result: dict) -> dict:
         overridden = result.copy()
         overridden["risk_level"] = best_level
         overridden["confidence"] = 0.85
+        # Recalibrar probabilities para ser coherentes con el nivel final.
+        # El nivel sobreescrito recibe 0.85; el resto se reparte equitativamente.
+        if result.get("probabilities"):
+            n = len(result["probabilities"])
+            resto = round((1.0 - 0.85) / max(n - 1, 1), 4)
+            overridden["probabilities"] = {
+                k: (0.85 if k == best_level else resto)
+                for k in result["probabilities"]
+            }
         overridden["annex3_override"] = True
         overridden["annex3_ref"] = best_ref
         overridden["ml_prediction"] = {
             "risk_level": result["risk_level"],
             "confidence": result["confidence"],
+            "probabilities": result.get("probabilities", {}),
         }
         return overridden
     return result

--- a/src/classifier/main.py
+++ b/src/classifier/main.py
@@ -128,11 +128,12 @@ def _annex3_override(text: str, result: dict) -> dict:
         # Recalibrar probabilities para ser coherentes con el nivel final.
         # El nivel sobreescrito recibe 0.85; el resto se reparte equitativamente.
         if result.get("probabilities"):
-            n = len(result["probabilities"])
+            keys = set(result["probabilities"].keys()) | {best_level}
+            n = len(keys)
             resto = round((1.0 - 0.85) / max(n - 1, 1), 4)
             overridden["probabilities"] = {
                 k: (0.85 if k == best_level else resto)
-                for k in result["probabilities"]
+                for k in keys
             }
         overridden["annex3_override"] = True
         overridden["annex3_ref"] = best_ref

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -330,3 +330,24 @@ class TestAnnex3Override:
         nivel = override_biometrico["risk_level"]
         probs = override_biometrico["probabilities"]
         assert probs[nivel] == max(probs.values())
+
+    def test_best_level_incluido_si_faltaba_en_probabilities_originales(self):
+        """Si best_level no estaba en el dict original, debe aparecer en el resultado."""
+        from src.classifier.main import _annex3_override
+        # Simula un dict de probabilities incompleto (sin alto_riesgo)
+        resultado_incompleto = {
+            "risk_level": "riesgo_minimo",
+            "confidence": 0.62,
+            "probabilities": {
+                "inaceptable": 0.15,
+                "riesgo_limitado": 0.13,
+                "riesgo_minimo": 0.72,
+                # alto_riesgo ausente intencionalmente
+            },
+        }
+        resultado = _annex3_override(
+            "evaluación del riesgo de recidiva para recomendar libertad condicional",
+            resultado_incompleto,
+        )
+        assert "alto_riesgo" in resultado["probabilities"]
+        assert resultado["probabilities"]["alto_riesgo"] == 0.85

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -226,3 +226,107 @@ class TestValidacionEntrada:
         from pydantic import ValidationError
         with pytest.raises(ValidationError):
             predict_risk("a" * 5001)
+
+
+# ---------------------------------------------------------------------------
+# Grupo 5: Annex III override — coherencia de campos post-override
+# ---------------------------------------------------------------------------
+
+# Resultado ML intencionalmente incorrecto para forzar el override en tests.
+# La función _annex3_override solo actúa cuando result["risk_level"] != best_level,
+# así que necesitamos un resultado ML que difiera del nivel que dicta el Anexo III.
+_MOCK_RESULT_ML = {
+    "risk_level": "riesgo_minimo",     # ML equivocado
+    "confidence": 0.62,
+    "probabilities": {
+        "inaceptable": 0.05,
+        "alto_riesgo": 0.20,
+        "riesgo_limitado": 0.13,
+        "riesgo_minimo": 0.62,
+    },
+    "shap_top_features": [{"feature": "chatbot", "contribution": 0.3}],
+}
+
+
+class TestAnnex3Override:
+    """Verifica que _annex3_override produce campos coherentes cuando actúa.
+
+    Este grupo cierra BUG-01: antes del fix, probabilities no se recalibraban
+    tras el override y podían contradecir risk_level.
+
+    Se testea _annex3_override directamente (unit tests) para no depender de
+    lo que el modelo ML prediga en cada reentrenamiento. Los textos elegidos
+    activan patrones del Anexo III de forma determinista.
+    """
+
+    @pytest.fixture(scope="class")
+    def override_recidiva(self):
+        """Override aplicado a texto de recidiva con predicción ML incorrecta."""
+        from src.classifier.main import _annex3_override
+        texto = "evaluación del riesgo de recidiva para recomendar libertad condicional"
+        return _annex3_override(texto, _MOCK_RESULT_ML.copy())
+
+    @pytest.fixture(scope="class")
+    def override_biometrico(self):
+        """Override aplicado a texto biométrico con predicción ML incorrecta."""
+        from src.classifier.main import _annex3_override
+        texto = (
+            "reconocimiento facial en tiempo real en espacios públicos "
+            "para identificación de personas"
+        )
+        return _annex3_override(texto, _MOCK_RESULT_ML.copy())
+
+    def test_override_activo_en_recidiva(self, override_recidiva):
+        """_annex3_override debe activar annex3_override=True para texto de recidiva."""
+        assert override_recidiva.get("annex3_override") is True
+
+    def test_risk_level_corregido_a_alto_riesgo(self, override_recidiva):
+        """El texto de recidiva debe sobreescribirse a alto_riesgo (Anexo III cat. 6)."""
+        assert override_recidiva["risk_level"] == "alto_riesgo"
+
+    def test_probabilities_coherentes_tras_override_recidiva(self, override_recidiva):
+        """probabilities[risk_level] debe ser el valor máximo del dict tras override."""
+        nivel = override_recidiva["risk_level"]
+        probs = override_recidiva["probabilities"]
+        assert probs[nivel] == max(probs.values()), (
+            f"BUG-01: probabilities no coherentes: risk_level='{nivel}' "
+            f"pero max prob es '{max(probs, key=probs.get)}'"
+        )
+
+    def test_confidence_igual_a_prob_del_nivel_asignado(self, override_recidiva):
+        """confidence debe coincidir con probabilities[risk_level] tras override."""
+        nivel = override_recidiva["risk_level"]
+        probs = override_recidiva["probabilities"]
+        assert override_recidiva["confidence"] == probs[nivel]
+
+    def test_probabilities_suman_uno_tras_override(self, override_recidiva):
+        """Las probabilities recalibradas deben sumar 1 (±0.02 por redondeo)."""
+        total = sum(override_recidiva["probabilities"].values())
+        assert abs(total - 1.0) < 0.02
+
+    def test_ml_prediction_preserva_risk_level_original(self, override_recidiva):
+        """ml_prediction debe guardar el risk_level que el ML predijo antes del override."""
+        ml = override_recidiva.get("ml_prediction", {})
+        assert ml.get("risk_level") == "riesgo_minimo"
+
+    def test_ml_prediction_preserva_probabilidades_originales(self, override_recidiva):
+        """ml_prediction debe incluir las probabilities ML originales para trazabilidad."""
+        ml = override_recidiva.get("ml_prediction", {})
+        assert "probabilities" in ml, "ml_prediction debe incluir 'probabilities'"
+        assert set(ml["probabilities"].keys()) == RISK_LEVELS
+        # Las probabilidades originales deben ser las del mock (ML incorrecto)
+        assert ml["probabilities"]["riesgo_minimo"] == 0.62
+
+    def test_override_activo_en_biometrico(self, override_biometrico):
+        """_annex3_override debe activar annex3_override=True para texto biométrico."""
+        assert override_biometrico.get("annex3_override") is True
+
+    def test_risk_level_corregido_a_inaceptable(self, override_biometrico):
+        """El texto biométrico en espacio público debe sobreescribirse a inaceptable."""
+        assert override_biometrico["risk_level"] == "inaceptable"
+
+    def test_probabilities_coherentes_tras_override_biometrico(self, override_biometrico):
+        """probabilities[risk_level] debe ser el valor máximo también para inaceptable."""
+        nivel = override_biometrico["risk_level"]
+        probs = override_biometrico["probabilities"]
+        assert probs[nivel] == max(probs.values())


### PR DESCRIPTION
## ¿Qué hace este PR?
Bug: Cuando _annex3_override corregía el risk_level por una regla determinista del Anexo III, actualizaba risk_level y confidence pero dejaba probabilities con los valores originales del ML. Resultado: la UI mostraba alto_riesgo al 85% de confianza pero en el desglose de probabilidades inaceptable aparecía al 99% — una contradicción visible.

Solución: En _annex3_override() (src/classifier/main.py), después de sobreescribir el nivel de riesgo, se recalibran las probabilities para que sean coherentes: el nivel final recibe 0.85 y el resto se reparte equitativamente. Las probabilidades ML originales se preservan en ml_prediction.probabilities para trazabilidad.

Se añaden 11 tests unitarios en TestAnnex3Override (tests/test_classifier.py) que llaman directamente a _annex3_override con un resultado ML intencionalmente incorrecto, verificando que los tres campos (risk_level, confidence, probabilities) son coherentes entre sí tras el override.

## Checklist (si aplica)
- [ ] He documentado mis decisiones en la documentación del proyecto.
- [x] El código pasa los tests localmente.
- [ ] He probado los cambios manualmente.

## ¿Afecta al trabajo de otros?
@Rcerezo-dev el cambio es en src/classifier/main.py. La estructura del dict de salida de predict_risk no cambia (mismas claves), solo los valores de probabilities son distintos cuando el override actúa. Si tienes código que lee probabilities directamente asumiendo que refleja la predicción ML, ahora refleja el nivel final. Las probabilidades ML originales están en result["ml_prediction"]["probabilities"].

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **New Features**
  * Mejora en la coherencia de resultados cuando se aplica validación de niveles de riesgo, recalibrando valores de confianza.

* **Tests**
  * Cobertura de pruebas ampliada de 69 a 79 tests.
  * Nuevas validaciones para garantizar consistencia de resultados.

* **Documentation**
  * Documentación actualizada con detalles sobre cobertura de pruebas expandida.
  * Información mejorada sobre capacidades de auditoría y trazabilidad del sistema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->