### PR TITLE
Bug 6: añadir en app.py logs básicos de los módulos

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,12 +4,20 @@ Chat conversacional con el orquestador LangGraph.
 Ejecutar: streamlit run app.py --server.port=8080
 """
 
+import logging
 import re
+import sys
 import uuid
 
 import streamlit as st
 
 from src.orchestrator.main import run
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    stream=sys.stdout,
+)
 
 st.set_page_config(page_title="NormaBot", page_icon="\u2696\ufe0f", layout="wide")
 

--- a/src/orchestrator/main.py
+++ b/src/orchestrator/main.py
@@ -28,8 +28,6 @@ except ImportError:
     class _NoOpLangfuse:
         def update_current_observation(self, **kwargs): pass
         def score_current_trace(self, **kwargs): pass
-        def flush(self): pass
-
     langfuse_context = _NoOpLangfuse()  # type: ignore[assignment]
 
 from src.observability.main import get_langfuse_handler
@@ -291,13 +289,6 @@ def run(query: str, session_id: str | None = None, user_id: str | None = None) -
         {"messages": [("user", query)]},
         config={"callbacks": callbacks},
     )
-    # Forzar envío inmediato para que las trazas aparezcan en Langfuse sin delay.
-    try:
-        for cb in callbacks:
-            cb.flush()
-        langfuse_context.flush()
-    except Exception as e:
-        logger.warning("Langfuse flush falló (traza puede llegar con delay): %s", e)
     return result
 
 

--- a/src/orchestrator/main.py
+++ b/src/orchestrator/main.py
@@ -28,6 +28,7 @@ except ImportError:
     class _NoOpLangfuse:
         def update_current_observation(self, **kwargs): pass
         def score_current_trace(self, **kwargs): pass
+        def flush(self): pass
 
     langfuse_context = _NoOpLangfuse()  # type: ignore[assignment]
 
@@ -290,6 +291,13 @@ def run(query: str, session_id: str | None = None, user_id: str | None = None) -
         {"messages": [("user", query)]},
         config={"callbacks": callbacks},
     )
+    # Forzar envío inmediato para que las trazas aparezcan en Langfuse sin delay.
+    try:
+        for cb in callbacks:
+            cb.flush()
+        langfuse_context.flush()
+    except Exception as e:
+        logger.warning("Langfuse flush falló (traza puede llegar con delay): %s", e)
     return result
 
 


### PR DESCRIPTION
## ¿Qué hace este PR?
* Añade logging.basicConfig en app.py para que los logs de todos los módulos (clasificador, informes, orquestador) lleguen a docker logs, no solo los del pipeline RAG.
  
## Checklist (si aplica)
- [ ] He documentado mis decisiones en la documentación del proyecto.
- [ ] El código pasa los tests localmente.
- [ ] He probado los cambios manualmente.

## ¿Afecta al trabajo de otros?
No.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Versión

* **Tareas**
  * Se añadió configuración de registro para mejorar la visibilidad operativa del sistema.

* **Estilo**
  * Se realizó limpieza de formato en el código.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->