### PR TITLE
Añadir acceso a EC2

### DIFF
--- a/infra/despliegue_develop.md
+++ b/infra/despliegue_develop.md
@@ -1,0 +1,223 @@
+# Acceso a los servidores EC2 de NormaBot
+
+## Requisitos previos
+
+- Cuenta AWS con acceso a la consola
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) instalado y configurado (`aws configure`)
+- Región configurada: `eu-west-1`
+
+---
+
+## 1. Crear tu clave SSH y enviarme la pública
+
+### macOS / Linux
+
+```bash
+ssh-keygen -t ed25519 -C "tu-nombre-normabot" -f ~/.ssh/normabot
+```
+
+Esto genera dos ficheros:
+- `~/.ssh/normabot` — clave privada (no la compartas con nadie)
+- `~/.ssh/normabot.pub` — clave pública (esta es la que me tienes que pasar)
+
+Para ver la clave pública:
+
+```bash
+cat ~/.ssh/normabot.pub
+```
+
+### Windows (PowerShell)
+
+```powershell
+ssh-keygen -t ed25519 -C "tu-nombre-normabot" -f "$env:USERPROFILE\.ssh\normabot"
+```
+
+Clave pública:
+
+```powershell
+cat "$env:USERPROFILE\.ssh\normabot.pub"
+```
+
+**Pásame el contenido de la clave pública por el canal privado de Discord o por DM — nunca la privada.**
+
+Una vez que me la mandes, yo la añado al servidor y te confirmo que ya puedes entrar.
+
+---
+
+## 2. Gestión de las instancias con AWS CLI
+
+> Usa esto solo cuando sea necesario. El reboot está pensado para cuando la instancia se queda colgada y no responde.
+
+### Obtener el estado e IP actual
+
+```bash
+# NormaBot (app principal)
+aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=NormaBot-Server" \
+  --query "Reservations[0].Instances[0].{Estado:State.Name,IP:PublicIpAddress,ID:InstanceId}" \
+  --output table \
+  --region eu-west-1
+
+# MLflow
+aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=MLflow-Server" \
+  --query "Reservations[0].Instances[0].{Estado:State.Name,IP:PublicIpAddress,ID:InstanceId}" \
+  --output table \
+  --region eu-west-1
+```
+
+### Start
+
+```bash
+# NormaBot
+aws ec2 start-instances \
+  --instance-ids $(aws ec2 describe-instances \
+    --filters "Name=tag:Name,Values=NormaBot-Server" \
+    --query "Reservations[0].Instances[0].InstanceId" \
+    --output text --region eu-west-1) \
+  --region eu-west-1
+
+# MLflow
+aws ec2 start-instances \
+  --instance-ids $(aws ec2 describe-instances \
+    --filters "Name=tag:Name,Values=MLflow-Server" \
+    --query "Reservations[0].Instances[0].InstanceId" \
+    --output text --region eu-west-1) \
+  --region eu-west-1
+```
+
+### Stop
+
+```bash
+# NormaBot
+aws ec2 stop-instances \
+  --instance-ids $(aws ec2 describe-instances \
+    --filters "Name=tag:Name,Values=NormaBot-Server" \
+    --query "Reservations[0].Instances[0].InstanceId" \
+    --output text --region eu-west-1) \
+  --region eu-west-1
+
+# MLflow
+aws ec2 stop-instances \
+  --instance-ids $(aws ec2 describe-instances \
+    --filters "Name=tag:Name,Values=MLflow-Server" \
+    --query "Reservations[0].Instances[0].InstanceId" \
+    --output text --region eu-west-1) \
+  --region eu-west-1
+```
+
+### Reboot
+
+> Solo si la instancia no responde. El reboot **no cambia la IP pública**.
+
+```bash
+# NormaBot
+aws ec2 reboot-instances \
+  --instance-ids $(aws ec2 describe-instances \
+    --filters "Name=tag:Name,Values=NormaBot-Server" \
+    --query "Reservations[0].Instances[0].InstanceId" \
+    --output text --region eu-west-1) \
+  --region eu-west-1
+
+# MLflow
+aws ec2 reboot-instances \
+  --instance-ids $(aws ec2 describe-instances \
+    --filters "Name=tag:Name,Values=MLflow-Server" \
+    --query "Reservations[0].Instances[0].InstanceId" \
+    --output text --region eu-west-1) \
+  --region eu-west-1
+```
+
+> **Aviso:** hacer un stop + start **cambia la IP pública** de la instancia. Después de arrancarla, consulta la IP actual con el comando `describe-instances` de arriba.
+
+---
+
+## 3. Conectarse por SSH
+
+> **La IP pública cambia cada vez que la instancia se para y se vuelve a arrancar.** Antes de conectarte, consulta la IP actual con el comando de abajo — no uses una IP guardada de una sesión anterior.
+
+### Obtener la IP actual
+
+```bash
+aws ec2 describe-instances \
+  --filters "Name=tag:Name,Values=NormaBot-Server" \
+  --query "Reservations[0].Instances[0].PublicIpAddress" \
+  --output text \
+  --region eu-west-1
+```
+
+### Conectarse
+
+```bash
+ssh -i ~/.ssh/normabot ubuntu@<IP>
+```
+
+Ejemplo:
+
+```bash
+ssh -i ~/.ssh/normabot ubuntu@34.244.146.100
+```
+
+---
+
+## 4. Despliegue manual
+
+Conéctate primero por SSH al servidor (sección anterior) y ejecuta los pasos en orden.
+
+### Limpiar
+
+```bash
+# 1. Para contenedores en marcha (si los hay)
+docker stop normabot && docker rm normabot
+
+# 2. Borra imágenes, contenedores parados y build cache
+docker system prune -a -f
+
+# 3. Borra volúmenes nombrados (NO incluidos en el paso anterior)
+docker volume rm ollama_models
+
+# 4. Verifica que hay espacio suficiente antes de continuar (lo habrá, no te preocupes)
+docker system df
+df -h /home/ubuntu/normabot
+```
+
+### Desplegar
+
+```bash
+# 1. Exportar variables del .env
+export $(grep -v '^#' /home/ubuntu/normabot/.env | xargs)
+
+# 2. Login al container registry con las credenciales del .env
+echo "$GHCR_READ_TOKEN" | docker login ghcr.io -u "$GHCR_READ_USER" --password-stdin
+
+# 3. Pull de la imagen más reciente
+docker pull ghcr.io/maquinas-que-aprenden/proyecto-final:develop
+
+# 4. Arrancar con el .env
+cd /home/ubuntu/normabot
+docker run -d --name normabot \
+  --user root \
+  -e HOME=/home/appuser \
+  -p 8080:8080 --env-file .env \
+  -v $(pwd)/data/processed/vectorstore:/app/data/processed/vectorstore \
+  -v ollama_models:/home/appuser/.ollama \
+  --entrypoint sh \
+  ghcr.io/maquinas-que-aprenden/proyecto-final:develop \
+  -c "/ollama-entrypoint.sh"
+
+# 5. Logout (buena práctica)
+docker logout ghcr.io
+```
+
+### Verificar que arrancó
+
+```bash
+docker ps
+```
+
+### Ver los logs mientras se ejecuta
+```bash
+docker logs -f normabot
+```
+
+> `docker logs -f` se queda siguiendo los logs en tiempo real. Pulsa **Ctrl+C** para salir — esto solo cierra la vista de logs, no para el contenedor.

--- a/infra/terraform/ec2.tf
+++ b/infra/terraform/ec2.tf
@@ -2,7 +2,6 @@ resource "aws_instance" "normabot_server" {
   ami                         = var.ami_id
   instance_type               = "t3.large"
   key_name                    = var.key_name
-  associate_public_ip_address = true
 
   subnet_id              = aws_subnet.public_subnet.id
   vpc_security_group_ids = [aws_security_group.normabot_sg.id]
@@ -58,6 +57,10 @@ resource "aws_instance" "mlflow_server" {
     volume_size           = 8
     volume_type           = "gp3"
     delete_on_termination = true
+  }
+
+  tags = {
+    Name = "MLflow-Server"
   }
 
   metadata_options {

--- a/infra/terraform/iam-users.tf
+++ b/infra/terraform/iam-users.tf
@@ -72,3 +72,43 @@ resource "aws_iam_group_policy_attachment" "dev_attach" {
   group      = aws_iam_group.dev_group.name
   policy_arn = aws_iam_policy.dev_s3_policy.arn
 }
+
+resource "aws_iam_group_policy_attachment" "dev_ec2_attach" {
+  group      = aws_iam_group.dev_group.name
+  policy_arn = aws_iam_policy.dev_ec2_policy.arn
+}
+
+resource "aws_iam_policy" "dev_ec2_policy" {
+  name        = "NormaBot-EC2-Deploy-Policy"
+  description = "Permite al equipo arrancar, parar y reiniciar los servidores NormaBot y MLflow"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EC2DeployActions"
+        Effect = "Allow"
+        Action = [
+          "ec2:StartInstances",
+          "ec2:StopInstances",
+          "ec2:RebootInstances"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/Name" = ["NormaBot-Server", "MLflow-Server"]
+          }
+        }
+      },
+      {
+        Sid    = "EC2ReadOnly"
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeInstances",
+          "ec2:DescribeInstanceStatus"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Añade terraform para que el grupo tenga acceso a EC2 en AWS CLI e instrucciones para hacer un despliegue manual.

## Checklist (si aplica)
- [ ] He documentado mis decisiones en la documentación del proyecto.
- [ ] El código pasa los tests localmente.
- [x] He probado los cambios manualmente.

## ¿Afecta al trabajo de otros?
Ahora vais a poder hacer start, stop y reinicio de las máquinas, y tenéis instrucciones para desplegar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Versión

* **Documentación**
  * Se agregó una guía completa de despliegue para acceder y gestionar servidores EC2 de NormaBot, incluyendo procedimientos de SSH, comandos de gestión de instancias y flujos de despliegue manual con Docker.

* **Chores**
  * Se actualizó la configuración de infraestructura EC2 e IAM para mejorar la gestión de instancias y permisos de acceso del equipo de desarrollo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->