### PR TITLE
fix(rag): bajar threshold score de 0.7 a 0.3 para distancia L2 (BUG-06)

### DIFF
--- a/src/rag/main.py
+++ b/src/rag/main.py
@@ -82,13 +82,13 @@ def retrieve(query: str, k: int = 9) -> list[dict]:
     return docs
 
 
-def _grade_by_score(docs: list[dict], threshold: float = 0.7) -> list[dict]:
+def _grade_by_score(docs: list[dict], threshold: float = 0.3) -> list[dict]:
     """Fallback: filtra documentos por score de similitud."""
     return [d for d in docs if d["score"] >= threshold]
 
 
 @observe(name="rag.grade")
-def grade(query: str, docs: list[dict], threshold: float = 0.7) -> list[dict]:
+def grade(query: str, docs: list[dict], threshold: float = 0.3) -> list[dict]:
     """Evalúa relevancia de cada documento con LLM local (Ollama).
 
     Fallback a filtro por score si Ollama no está disponible.


### PR DESCRIPTION
## Problema

El threshold `0.7` en `_grade_by_score()` y `grade()` estaba calibrado para distancia coseno, pero ChromaDB usa **distancia L2 por defecto**.

Con distancia L2², la fórmula `score = 1 - distance` no es equivalente a similitud coseno. Un documento con cosine_similarity=0.75 obtiene score=0.50 y era descartado. Resultado: contexto vacío → RAGAS mide 0 relevancia en 10/16 consultas.

## Causa raíz

```
L2² = 2 × (1 - cosine_similarity)
```

| Cosine sim real | Score calculado (1 - L2²) | ¿Pasaba threshold 0.7? |
|---|---|---|
| 0.95 | 0.90 | ✅ |
| 0.85 | 0.70 | ⚠️ Justo |
| 0.75 | 0.50 | ❌ Descartado |
| 0.60 | 0.20 | ❌ Descartado |

## Fix

Cambiar threshold de `0.7` a `0.3`. Con distancia L2², threshold 0.3 equivale a exigir cosine_sim > 0.70 — estándar en RAG.

## Archivos modificados

- `src/rag/main.py` — threshold en `_grade_by_score()` y `grade()`: `0.7 → 0.3`

## Test plan

- [ ] Ejecutar `python -m src.rag.main` y verificar que devuelve docs relevantes
- [ ] Re-ejecutar evaluación RAGAS y comparar métricas con evaluación anterior (10/16 con 0 relevancia)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de la versión

* **Correcciones de errores**
  * Se ha reducido el umbral predeterminado para el filtrado de documentos relevantes de 0.7 a 0.3. Esto amplía el conjunto de documentos considerados como relevantes durante el proceso de evaluación, permitiendo un análisis más exhaustivo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->