### PR TITLE
feat: añadir playbooks Ansible para máquina GPU y config docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,13 @@ services:
       - ollama_models:/home/appuser/.ollama
       - normabot_memory:/app/data/memory
     restart: unless-stopped
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
 
 volumes:
   ollama_models:

--- a/docs/mlops/guia-de-trabajo.md
+++ b/docs/mlops/guia-de-trabajo.md
@@ -114,12 +114,15 @@ Para desplegar o destruir hay que tener permisos para crear los recursos en AWS,
 * Estos son los ficheros actuales:
 ```
 .
-├── inventory.ini           # inventario de servidores, generado automáticamente por terraform (no se sube a github)
-├── mlflow_deploy.yaml      # configuración de mlflow
-├── mlflow_ebs.yaml         # configuración de ebs de mlflow
-├── normabot_ebs.yaml       # monta el EBS de normabot y mueve el data-root de Docker al EBS
-├── normabot_data.yaml      # instala DVC, clona el repo y descarga el vectorstore desde S3
-├── playbook.yaml           # configuración general de ambos servidores
+├── inventory.ini               # inventario de servidores, generado automáticamente por terraform (no se sube a github)
+├── mlflow_deploy.yaml          # configuración de mlflow
+├── mlflow_ebs.yaml             # configuración de ebs de mlflow
+├── normabot_ebs.yaml           # monta el EBS por UUID, configura docker-data y containerd en el EBS
+├── normabot_data.yaml          # instala DVC, clona el repo (main) y descarga el vectorstore desde S3
+├── normabot_gpu.yaml           # instala drivers NVIDIA 535 + nvidia-container-toolkit (g4dn.xlarge / Tesla T4)
+├── normabot_gpu_ebs.yaml       # igual que normabot_ebs.yaml pero con auto-detección del dispositivo EBS
+├── normabot_gpu_data.yaml      # igual que normabot_data.yaml pero apunta a hosts: normabot_gpu
+├── playbook.yaml               # configuración base de todos los servidores (docker, git, aws cli)
 └── templates
     ├── docker-compose.yml.j2   # necesario para despliegue de mlflow
     └── nginx.conf.j2           # necesario para securizar acceso a mlflow
@@ -136,7 +139,6 @@ Para desplegar o destruir hay que tener permisos para crear los recursos en AWS,
 <IP> ansible_user=ubuntu ansible_ssh_private_key_file=~/.ssh/aws.pem
 
 ```
-**Nota**: los playbooks `normabot_ebs.yaml` y `normabot_data.yaml` tienen `hosts: normabot`. Para ejecutarlos contra el servidor GPU hay que añadir su IP al grupo `[normabot]` (o al grupo `[normabot_gpu]` y cambiar el `hosts:` del playbook).
 
 #### Cómo ejecutar
 Existe un orden para ejecutarlos.
@@ -148,9 +150,17 @@ ansible-playbook -i inventory.ini playbook.yaml
 ansible-playbook -i inventory.ini mlflow_ebs.yaml
 ansible-playbook -i inventory.ini mlflow_deploy.yaml -e "mlflow_password=<password>"
 
-# Para normabot (solo la primera vez o si se recrea desde cero la instancia):
+# Para normabot CPU (solo la primera vez o si se recrea desde cero la instancia):
 ansible-playbook -i inventory.ini normabot_ebs.yaml
 ansible-playbook -i inventory.ini normabot_data.yaml
+
+# Para normabot GPU (g4dn.xlarge — solo la primera vez o si se recrea desde cero):
+ansible-playbook -i inventory.ini playbook.yaml          # base: docker, git, aws cli
+ansible-playbook -i inventory.ini normabot_gpu.yaml      # nvidia drivers + container toolkit (hace reboot si instala drivers nuevos)
+ansible-playbook -i inventory.ini normabot_gpu_ebs.yaml  # monta EBS por UUID, configura docker-data y containerd
+ansible-playbook -i inventory.ini normabot_gpu_data.yaml # clona repo (main), instala dvc, hace pull del vectorstore
+# Para clonar develop en lugar de main:
+ansible-playbook -i inventory.ini normabot_gpu_data.yaml -e "git_branch=develop"
 ```
 En el caso de `mlflow_deploy` es necesario pasar la contraseña para que nginx impida acceder a cualquiera. La contraseña está en nuestro gestor de contraseñas compartido.
 

--- a/infra/ansible/normabot_gpu.yaml
+++ b/infra/ansible/normabot_gpu.yaml
@@ -1,0 +1,62 @@
+---
+- name: Configurar GPU NVIDIA en NormaBot (g4dn.xlarge - Tesla T4)
+  hosts: normabot_gpu
+  become: true
+
+  tasks:
+    - name: Instalar driver NVIDIA 535
+      apt:
+        name:
+          - nvidia-driver-535
+          - nvidia-utils-535
+        state: present
+        install_recommends: false
+      register: nvidia_driver_installed
+
+    - name: Añadir GPG key de nvidia-container-toolkit
+      shell: |
+        curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
+          gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+      args:
+        creates: /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+
+    - name: Añadir repositorio de nvidia-container-toolkit
+      shell: |
+        curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+          sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+          tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+      args:
+        creates: /etc/apt/sources.list.d/nvidia-container-toolkit.list
+
+    - name: Actualizar caché apt
+      apt:
+        update_cache: yes
+
+    - name: Instalar nvidia-container-toolkit
+      apt:
+        name: nvidia-container-toolkit
+        state: present
+
+    - name: Configurar Docker runtime para NVIDIA
+      shell: nvidia-ctk runtime configure --runtime=docker
+      notify: Restart Docker
+
+    - name: Reiniciar si se instalaron drivers nuevos
+      ansible.builtin.reboot:
+        reboot_timeout: 120
+      when: nvidia_driver_installed.changed
+
+    - name: Verificar que nvidia-smi funciona
+      command: nvidia-smi
+      register: nvidia_smi_output
+      changed_when: false
+
+    - name: Mensaje final
+      debug:
+        msg: "{{ nvidia_smi_output.stdout_lines[0] }}"
+
+  handlers:
+    - name: Restart Docker
+      ansible.builtin.systemd:
+        name: docker
+        state: restarted

--- a/infra/ansible/normabot_gpu_data.yaml
+++ b/infra/ansible/normabot_gpu_data.yaml
@@ -1,11 +1,11 @@
 ---
 - name: Configurar DVC y datos en NormaBot
-  hosts: normabot
+  hosts: normabot_gpu
   become: true
 
   vars:
     project_path: "/home/ubuntu/normabot"
-    git_branch: "main"
+    git_branch: "main"  # sobreescribir con -e git_branch=develop para experimentación
 
   tasks:
     - name: Instalar pipx
@@ -30,7 +30,7 @@
         path: "{{ project_path }}/.dvc/config"
       register: dvc_config
 
-    - name: Clonar repositorio (shallow)
+    - name: Clonar repositorio (shallow) y quedarse en rama correcta
       become: false
       shell: |
         cd {{ project_path }}
@@ -40,7 +40,7 @@
         git remote remove origin 2>/dev/null || true
         git remote add origin https://github.com/maquinas-que-aprenden/proyecto-final.git
         git fetch --depth 1 origin {{ git_branch }}
-        git checkout FETCH_HEAD
+        git checkout -B {{ git_branch }} FETCH_HEAD
       when: not dvc_config.stat.exists
 
     - name: Corregir permisos de lost+found (creado por root al formatear EBS)
@@ -51,7 +51,7 @@
         mode: "0755"
       ignore_errors: true
 
-    - name: Corregir permisos del directorio .dvc (puede quedar con permisos de root)
+    - name: Corregir permisos del directorio .dvc
       ansible.builtin.file:
         path: "{{ project_path }}/.dvc"
         owner: ubuntu
@@ -59,7 +59,7 @@
         recurse: true
       ignore_errors: true
 
-    - name: Corregir permisos del directorio data (datos gestionados por DVC)
+    - name: Corregir permisos del directorio data
       ansible.builtin.file:
         path: "{{ project_path }}/data"
         owner: ubuntu

--- a/infra/ansible/normabot_gpu_ebs.yaml
+++ b/infra/ansible/normabot_gpu_ebs.yaml
@@ -1,0 +1,111 @@
+- name: Configurar EBS en NormaBot (solo al crear la instancia desde cero)
+  hosts: normabot_gpu
+  become: true
+  vars:
+    project_path: "/home/ubuntu/normabot"
+    ebs_fstype: "ext4"
+
+  tasks:
+    - name: Detectar el dispositivo EBS de datos (el que no es raíz ni está montado)
+      shell: |
+        lsblk -dpno NAME,TYPE | awk '$2=="disk" {print $1}' | while read dev; do
+          mountpoint=$(lsblk -no MOUNTPOINTS "$dev" 2>/dev/null | grep -v '^$' | head -1)
+          if [ -z "$mountpoint" ]; then
+            echo "$dev"
+            break
+          fi
+        done
+      register: ebs_device_raw
+      changed_when: false
+
+    - name: Formatear volumen de datos (solo si no tiene filesystem)
+      community.general.filesystem:
+        fstype: "{{ ebs_fstype }}"
+        dev: "{{ ebs_device_raw.stdout }}"
+        force: false
+
+    - name: Obtener UUID del volumen por dispositivo
+      command: blkid -s UUID -o value {{ ebs_device_raw.stdout }}
+      register: ebs_uuid
+      changed_when: false
+
+    - name: Crear directorio de montaje si no existe
+      ansible.builtin.file:
+        path: "{{ project_path }}"
+        state: directory
+        owner: ubuntu
+        group: ubuntu
+        mode: "0755"
+
+    - name: Montar EBS usando UUID (independiente del nombre de dispositivo)
+      mount:
+        path: "{{ project_path }}"
+        src: "UUID={{ ebs_uuid.stdout }}"
+        fstype: ext4
+        opts: defaults,nofail
+        state: mounted
+
+    - name: Asegurar permisos tras el montaje
+      ansible.builtin.file:
+        path: "{{ project_path }}"
+        owner: ubuntu
+        group: ubuntu
+        mode: "0755"
+        state: directory
+
+    - name: Crear directorio docker-data en el EBS
+      ansible.builtin.file:
+        path: "{{ project_path }}/docker-data"
+        state: directory
+        owner: ubuntu
+        group: ubuntu
+        mode: "0755"
+
+    - name: Crear directorio containerd-data en el EBS
+      ansible.builtin.file:
+        path: "{{ project_path }}/containerd-data"
+        state: directory
+        owner: ubuntu
+        group: ubuntu
+        mode: "0755"
+
+    - name: Configurar Docker data-root en el EBS
+      ansible.builtin.copy:
+        dest: /etc/docker/daemon.json
+        content: |
+          {
+            "data-root": "{{ project_path }}/docker-data"
+          }
+        mode: "0644"
+      notify: Restart Docker
+
+    - name: Generar configuración base de containerd
+      shell: containerd config default > /etc/containerd/config.toml
+      args:
+        creates: /etc/containerd/config.toml
+
+    - name: Configurar containerd para usar el EBS
+      ansible.builtin.replace:
+        path: /etc/containerd/config.toml
+        regexp: "root = '.*'"
+        replace: "root = '{{ project_path }}/containerd-data'"
+      notify: Restart Containerd
+
+    - name: Recargar systemd
+      ansible.builtin.systemd:
+        daemon_reload: true
+
+    - name: Mensaje final
+      ansible.builtin.debug:
+        msg: "EBS montado en {{ project_path }} con UUID={{ ebs_uuid.stdout }}. Docker y containerd configurados."
+
+  handlers:
+    - name: Restart Docker
+      ansible.builtin.systemd:
+        name: docker
+        state: restarted
+
+    - name: Restart Containerd
+      ansible.builtin.systemd:
+        name: containerd
+        state: restarted


### PR DESCRIPTION
## ¿Qué hace este PR?
Playbooks para instancia g4dn.xlarge (Tesla T4):
- normabot_gpu.yaml: drivers NVIDIA 535 + nvidia-container-toolkit
- normabot_gpu_ebs.yaml: montaje EBS con auto-detección de dispositivo, configura docker-data y containerd-data en el EBS
- normabot_gpu_data.yaml: DVC + clone del repo (main por defecto, sobreescribir con -e git_branch=develop para experimentación)

Cambios en existentes:
- normabot_data.yaml: dvc pull usa .dvc pointer file en lugar de path
- docker-compose.yml: añadir reserva de GPU NVIDIA para contenedor normabot
- docs/mlops/guia-de-trabajo.md: documentar nuevos playbooks GPU y orden de ejecución para instancia g4dn.xlarge

## Checklist (si aplica)
- [x] He documentado mis decisiones en la documentación del proyecto.
- [x] El código pasa los tests localmente.
- [x] He probado los cambios manualmente.

## ¿Afecta al trabajo de otros?
Dejando todo preparado para el CD.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de la versión

* **Nuevas Características**
  * Se agregó soporte de GPU para despliegues de producción con restricciones de recursos configuradas.
  * Se habilitaron flujos de trabajo automatizados para provisionar infraestructura, configurar aceleración de GPU y gestionar volúmenes de almacenamiento.

* **Documentación**
  * Se actualizó la guía de implementación con instrucciones para despliegues con aceleración GPU y nuevos flujos de trabajo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->